### PR TITLE
Add 'mvp/start-all.sh' for launching the system without needing a Mac

### DIFF
--- a/mvp/start-all.sh
+++ b/mvp/start-all.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+./start-gui.sh
+./start-server.sh

--- a/mvp/start-gui.sh
+++ b/mvp/start-gui.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+racket gui.rkt &

--- a/mvp/start-server.sh
+++ b/mvp/start-server.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+scheme mcp.scm &
+sleep 3
+scheme scp.scm &
+sleep 3
+scheme scp.scm &


### PR DESCRIPTION
This PR adds a script for launching the system without needing a Mac, since `mvp/start.sh` currently uses the `osascript` command (Applescript).